### PR TITLE
Change to real semantic versions for snapshots

### DIFF
--- a/post-release/entrypoint.sh
+++ b/post-release/entrypoint.sh
@@ -48,12 +48,12 @@ echo "Creating new milestone"
 curl -s --request POST -H "Authorization: Bearer $1" -H "Content-Type: application/json" "https://api.github.com/repos/$GITHUB_REPOSITORY/milestones" --data "{\"title\": \"$next_version\"}"
 
 echo "Setting new snapshot version"
-sed -i "s/^projectVersion.*$/projectVersion\=${next_version}.BUILD-SNAPSHOT/" gradle.properties
+sed -i "s/^projectVersion.*$/projectVersion\=${next_version}-SNAPSHOT/" gradle.properties
 cat gradle.properties
 
 echo "Committing and pushing"
 git add gradle.properties
-git commit -m "Back to ${next_version}.BUILD-SNAPSHOT"
+git commit -m "Back to ${next_version}-SNAPSHOT"
 git push origin $target_branch
 
 echo "Setting release version back so that Maven Central sync can work"


### PR DESCRIPTION
Fixes #6

This change will be applied automatically to the different modules after we release new versions.

For Starter, once this is merged I'll send a new PR to change it here https://github.com/micronaut-projects/micronaut-starter/blob/976136aaeba80ee7ca283cbc2131068fc2e2ed12/.github/workflows/release.yml#L70. I'll also manually modify the current `.BUILD-SNAPSHOT` to `-SNAPSHOT` in 2.3.x

For Core I'll also send a manual PR to start publishing the "new" snapshots for 2.3.0 (and I'll update the docs)