### PR TITLE
Customize Actions

### DIFF
--- a/post-release/entrypoint.sh
+++ b/post-release/entrypoint.sh
@@ -11,8 +11,8 @@ echo $next_version
 echo ::set-output name=next_version::${next_version}
 
 echo "Configuring git"
-git config --global user.email "$MICRONAUT_BUILD_EMAIL"
-git config --global user.name "micronaut-build"
+git config --global user.email "$GIT_USER_EMAIL"
+git config --global user.name "$GIT_USER_NAME"
 git fetch
 
 echo -n "Determining target branch: "

--- a/post-release/entrypoint.sh
+++ b/post-release/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # $1 == GH_TOKEN
 
+if [ -z "$SNAPSHOT_SUFFIX" ]; then
+  SNAPSHOT_SUFFIX="-SNAPSHOT"
+fi
+
 echo -n "Determining release version: "
 release_version=${GITHUB_REF:11}
 echo $release_version
@@ -48,12 +52,12 @@ echo "Creating new milestone"
 curl -s --request POST -H "Authorization: Bearer $1" -H "Content-Type: application/json" "https://api.github.com/repos/$GITHUB_REPOSITORY/milestones" --data "{\"title\": \"$next_version\"}"
 
 echo "Setting new snapshot version"
-sed -i "s/^projectVersion.*$/projectVersion\=${next_version}-SNAPSHOT/" gradle.properties
+sed -i "s/^projectVersion.*$/projectVersion\=${next_version}$SNAPSHOT_SUFFIX/" gradle.properties
 cat gradle.properties
 
 echo "Committing and pushing"
 git add gradle.properties
-git commit -m "Back to ${next_version}-SNAPSHOT"
+git commit -m "Back to ${next_version}$SNAPSHOT_SUFFIX"
 git push origin $target_branch
 
 echo "Setting release version back so that Maven Central sync can work"

--- a/post-release/entrypoint.sh
+++ b/post-release/entrypoint.sh
@@ -5,6 +5,18 @@ if [ -z "$SNAPSHOT_SUFFIX" ]; then
   SNAPSHOT_SUFFIX="-SNAPSHOT"
 fi
 
+if [ -n "$MICRONAUT_BUILD_EMAIL" ]; then
+    GIT_USER_EMAIL=$MICRONAUT_BUILD_EMAIL
+fi
+
+if [ -z "$GIT_USER_EMAIL" ]; then
+   GIT_USER_EMAIL="${GITHUB_ACTOR}@users.noreply.github.com"
+fi
+
+if [ -z "$GIT_USER_NAME" ]; then
+   GIT_USER_NAME="micronaut-build"
+fi
+
 echo -n "Determining release version: "
 release_version=${GITHUB_REF:11}
 echo $release_version

--- a/pre-release/entrypoint.sh
+++ b/pre-release/entrypoint.sh
@@ -5,6 +5,14 @@ echo -n "Determining release version: "
 release_version=${GITHUB_REF:11}
 echo $release_version
 
+if [ -n "$MICRONAUT_BUILD_EMAIL" ]; then
+    GIT_USER_EMAIL=$MICRONAUT_BUILD_EMAIL
+fi
+
+if [ -z "$GIT_USER_NAME" ]; then
+   GIT_USER_NAME="micronaut-build"
+fi
+
 echo "Configuring git"
 git config --global user.email "$GIT_USER_EMAIL"
 git config --global user.name "$GIT_USER_NAME"

--- a/pre-release/entrypoint.sh
+++ b/pre-release/entrypoint.sh
@@ -6,8 +6,8 @@ release_version=${GITHUB_REF:11}
 echo $release_version
 
 echo "Configuring git"
-git config --global user.email "$MICRONAUT_BUILD_EMAIL"
-git config --global user.name "micronaut-build"
+git config --global user.email "$GIT_USER_EMAIL"
+git config --global user.name "$GIT_USER_NAME"
 git fetch
 
 echo -n "Determining target branch: "

--- a/update-bom/entrypoint.sh
+++ b/update-bom/entrypoint.sh
@@ -4,8 +4,8 @@
 set -e
 
 echo "Configuring git"
-git config --global user.email "$MICRONAUT_BUILD_EMAIL"
-git config --global user.name "micronaut-build"
+git config --global user.email "$GIT_USER_EMAIL"
+git config --global user.name "$GIT_USER_NAME"
 cd micronaut-core
 projectName="${GITHUB_REPOSITORY:19}"
 git checkout -b "$projectName-$projectVersion"

--- a/update-bom/entrypoint.sh
+++ b/update-bom/entrypoint.sh
@@ -3,6 +3,18 @@
 
 set -e
 
+if [ -n "$MICRONAUT_BUILD_EMAIL" ]; then
+    GIT_USER_EMAIL=$MICRONAUT_BUILD_EMAIL
+fi
+
+if [ -z "$GIT_USER_EMAIL" ]; then
+   GIT_USER_EMAIL="${GITHUB_ACTOR}@users.noreply.github.com"
+fi
+
+if [ -z "$GIT_USER_NAME" ]; then
+   GIT_USER_NAME="micronaut-build"
+fi
+
 echo "Configuring git"
 git config --global user.email "$GIT_USER_EMAIL"
 git config --global user.name "$GIT_USER_NAME"


### PR DESCRIPTION
* Flexibility to configure snapshot suffix using env `SNAPSHOT_SUFFIX`, e.g. 1.0.0.BUILD-SNAPSHOT or 1.0.0-SNAPSHOT (defaults to 1.0.0-SNAPSHOT).
* Provide env `GIT_USER_NAME` ( default to micronaut-build)
* Provide env `GIT_USER_EMAIL` which default to env `MICRONAUT_BUILD_EMAIL` if present, otherwise "`${GITHUB_ACTOR}`@users.noreply.github.com"