### PR TITLE
Skip CI workflows for release commit

### DIFF
--- a/pre-release/entrypoint.sh
+++ b/pre-release/entrypoint.sh
@@ -29,7 +29,7 @@ cat gradle.properties
 
 echo "Pushing release version and recreating v${release_version} tag"
 git add gradle.properties
-git commit -m "Release v${release_version}"
+git commit -m "[skip ci] Release v${release_version}"
 git push origin $target_branch
 git push origin :refs/tags/v${release_version}
 git tag -fa v${release_version} -m "Release v${release_version}"


### PR DESCRIPTION
With this change the commit for the release won't trigger the execution of the CI workflows.

More info: https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/