### PR TITLE
Handle Micronaut core version catalog in BOM update

### DIFF
--- a/update-bom/entrypoint.sh
+++ b/update-bom/entrypoint.sh
@@ -3,6 +3,8 @@
 
 set -e
 
+CATALOG_FILE=gradle/libs.versions.toml
+
 if [ -n "$MICRONAUT_BUILD_EMAIL" ]; then
     GIT_USER_EMAIL=$MICRONAUT_BUILD_EMAIL
 fi
@@ -40,6 +42,29 @@ then
     done
 fi
 
+if [ -f $CATALOG_FILE ]; then
+    echo "Updating version catalog..."
+    if [ ! -z $bomProperty ]; 
+    then
+        catalogProperty=$(echo $bomProperty | sed -r 's/([a-z0-9])([A-Z])/\1-\L\2/g' | sed -r 's/-version$//g')
+        echo "name: $catalogProperty"
+        echo "value: ${!$bomProperty}"
+        sed -i -E "s/^(managed-)?$catalogProperty\s*=\s*\".*$/\1$catalogProperty \= "${projectVersion}"/" $CATALOG_FILE
+    fi
+
+    if [ ! -z $bomProperties ]; 
+    then
+        IFS=','
+        for property in $bomProperties
+        do
+            catalogProperty=$(echo $property | sed -r 's/([a-z0-9])([A-Z])/\1-\L\2/g' | sed -r 's/-version$//g')
+            echo "name: $catalogProperty"
+            echo "value: ${!property}"
+            sed -i -E "s/^(managed-)?$catalogProperty\s*=\s*\".*$/\1$catalogProperty \= "${!property}"/" $CATALOG_FILE       
+        done
+    fi
+fi
+
 echo "Changes Applied"
 git diff
 
@@ -47,6 +72,9 @@ if [ -z $DRY_RUN ]
 then
     echo "Creating pull request"
     git add gradle.properties
+    if [ -f $CATALOG_FILE ]; then
+        git add $CATALOG_FILE
+    fi
     git commit -m "Bump $projectName to $projectVersion"
     git push origin "$projectName-$projectVersion"
     pr_url=`curl -s --request POST -H "Authorization: Bearer $1" -H "Content-Type: application/json" https://api.github.com/repos/micronaut-projects/micronaut-core/pulls --data "{\"title\": \"Bump $projectName to $projectVersion\", \"head\":\"$projectName-$projectVersion\", \"base\":\"$githubCoreBranch\"}" | jq '.issue_url' | sed -e 's/^"\(.*\)"$/\1/g'`


### PR DESCRIPTION
This commit adds handling of version catalogs in the Micronaut core
BOM project. To preserve compatibility with how the various project
define how they update the BOM, a conversion is made from the
properties notation (e.g. `micronautDataVersion`) to the catalog
notation `micronaut-data`.

This makes it possible to use this action _without_ updating all
Micronaut projects `gradle.properties` file.

This does NOT handle projects which would potentially use version
catalogs themselves. In other words, only `core` is expected to
use catalogs at this point.

Follow up to https://github.com/micronaut-projects/micronaut-core/pull/6067#issuecomment-913728258