### PR TITLE
Reset IFS

### DIFF
--- a/update-bom/entrypoint.sh
+++ b/update-bom/entrypoint.sh
@@ -42,13 +42,15 @@ then
     done
 fi
 
+IFS=''
+
 if [ -f $CATALOG_FILE ]; then
     echo "Updating version catalog..."
     if [ ! -z $bomProperty ];
     then
         if [[ -z "$catalogProperty" ]];
         then
-          catalogProperty=$(echo $bomProperty | sed -r -E 's/([a-z0-9])([A-Z])/\1-\L\2/g' | sed -r 's/-version$//g' )
+          catalogProperty=$(echo $bomProperty | sed -r -E 's/([a-z0-9])([A-Z])/\1-\L\2/g' | sed -r -E 's/-version$//g' )
         fi
         echo "name: $catalogProperty"
         echo "value: ${!bomProperty}"
@@ -60,7 +62,7 @@ if [ -f $CATALOG_FILE ]; then
         IFS=','
         for property in $bomProperties
         do
-            catalogProperty=$(echo $property | sed -r -E 's/([a-z0-9])([A-Z])/\1-\L\2/g' | sed -r 's/-version$//g')
+            catalogProperty=$(echo $property | sed -r -E 's/([a-z0-9])([A-Z])/\1-\L\2/g' | sed -r -E 's/-version$//g')
             echo "name: $catalogProperty"
             echo "value: ${!property}"
             sed -i -E "s/^(managed-)?$catalogProperty\s*=\s*\".*$/\1$catalogProperty = \"${!property}\"/" $CATALOG_FILE


### PR DESCRIPTION
If the `bomProperties` property was present, the second loop which
iterates on bom properties would fail because the IFS property
wasn't reset in between.
