### PR TITLE
Add GNU sed

### DIFF
--- a/update-bom/Dockerfile
+++ b/update-bom/Dockerfile
@@ -1,7 +1,7 @@
 # Container image that runs your code
 FROM alpine:3
 
-RUN apk add --no-cache curl jq git bash
+RUN apk add --no-cache curl jq git bash sed
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
We need a "real" `sed`:

```
ivan@doraemon:~$ docker run -it --rm alpine:3 sh                                                                  / # sed --version
This is not GNU sed version 4.0

/ # apk add sed
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
(1/1) Installing sed (4.8-r0)
Executing busybox-1.33.1-r3.trigger
OK: 6 MiB in 15 packages

/ # sed --version
sed (GNU sed) 4.8
```