### PR TITLE
post-release action to accept additional params

### DIFF
--- a/post-release/entrypoint.sh
+++ b/post-release/entrypoint.sh
@@ -18,7 +18,11 @@ if [ -z "$GIT_USER_NAME" ]; then
 fi
 
 echo -n "Determining release version: "
-release_version=${GITHUB_REF:11}
+if [ -z "$RELEASE_VERSION" ]; then
+  release_version=${GITHUB_REF:11}
+else
+  release_version=${RELEASE_VERSION}
+fi
 echo $release_version
 
 echo -n "Determining next version: "
@@ -32,7 +36,11 @@ git config --global user.name "$GIT_USER_NAME"
 git fetch
 
 echo -n "Determining target branch: "
-target_branch=`cat $GITHUB_EVENT_PATH | jq '.release.target_commitish' | sed -e 's/^"\(.*\)"$/\1/g'`
+if [ -z "$TARGET_BRANCH" ]; then
+  target_branch=`cat $GITHUB_EVENT_PATH | jq '.release.target_commitish' | sed -e 's/^"\(.*\)"$/\1/g'`
+else
+  target_branch=${TARGET_BRANCH}
+fi
 echo $target_branch
 git checkout $target_branch
 


### PR DESCRIPTION
In Grails® framework, sometime the publish to OSSRH fails(or timeout) so we have implemented a workflow "Retry Release" which is triggered manually once OSSRH staging repository validation and release completes. This pull-request allows to pass release_version and target_branch, otherwise it will resolve them from GITHUB_REF and GITHUB_EVENT_PATH environment variables.