### PR TITLE
Remove COMMIT_EDITMSG file after git in docker

### DIFF
--- a/post-release/entrypoint.sh
+++ b/post-release/entrypoint.sh
@@ -80,6 +80,10 @@ git add gradle.properties
 git commit -m "Back to ${next_version}$SNAPSHOT_SUFFIX"
 git push origin $target_branch
 
+# Clean up .git artifacts we've created as root (so non-docker actions that follow can use git without re-cloning)
+echo "Cleaning up artifacts with excessive permissions"
+rm -f .git/COMMIT_EDITMSG
+
 echo "Setting release version back so that Maven Central sync can work"
 sed -i "s/^projectVersion.*$/projectVersion\=${release_version}/" gradle.properties
 cat gradle.properties


### PR DESCRIPTION
After running git inside the container, a `COMMIT_EDITMSG` file is created that cannot be overwritten
by subsequent non-dockerized git commands (without a re-clone of the project)

[Example here](https://github.com/micronaut-projects/micronaut-starter/runs/4972440306?check_suite_focus=true#step:12:27)

This change cleans up the file once done