### PR TITLE
Latest GraalVM github action changes

### DIFF
--- a/graalvm/build-matrix/action.yml
+++ b/graalvm/build-matrix/action.yml
@@ -42,6 +42,6 @@ runs:
         else
           echo "Native test tasks not found"
         fi
-        matrixValue="{$(echo $nativeTestTasksEntry)\"graalvm\":[\"${{ inputs.graalvm }}\"],\"java\":[\"${{ inputs.java }}\"]}"
+        matrixValue="{$(echo $nativeTestTasksEntry)\"distribution\":[\"${{ inputs.distribution }}\"],\"java\":[\"${{ inputs.java }}\"]}"
         echo "Created matrix: $matrixValue"
         echo "matrix=$matrixValue" >> $GITHUB_OUTPUT

--- a/graalvm/build-matrix/action.yml
+++ b/graalvm/build-matrix/action.yml
@@ -13,7 +13,7 @@ runs:
         fetch-depth: 0
 
     - name: "Setup GraalVM CE"
-      uses: graalvm/setup-graalvm@v1
+      uses: graalvm/setup-graalvm@v1.1.1
       with:
         distribution: 'graalvm-community'
         java-version: '17'

--- a/graalvm/build-matrix/action.yml
+++ b/graalvm/build-matrix/action.yml
@@ -13,7 +13,7 @@ runs:
         fetch-depth: 0
 
     - name: "Setup GraalVM CE"
-      uses: graalvm/setup-graalvm@v1.0.12
+      uses: graalvm/setup-graalvm@v1
       with:
         distribution: 'graalvm-community'
         java-version: '17'

--- a/graalvm/build-matrix/action.yml
+++ b/graalvm/build-matrix/action.yml
@@ -1,12 +1,5 @@
 name: Build matrix for graalvm workflow
 description: Creates matrix for graalvm workflow
-inputs:
-  distribution:
-    description: 'GraalVM distribution (graalvm, graalvm-community, or mandrel)'
-    required: true
-  java:
-    description: 'Java version'
-    required: true
 outputs:
   matrix:
     description: "Matrix for native tests"
@@ -22,8 +15,8 @@ runs:
     - name: "Setup GraalVM CE"
       uses: graalvm/setup-graalvm@v1
       with:
-        distribution: ${{ inputs.distribution }}
-        java-version: ${{ inputs.java }}
+        distribution: 'graalvm-community'
+        java-version: '17'
 
     - name: "Setup Gradle"
       uses: gradle/gradle-build-action@v2
@@ -41,6 +34,6 @@ runs:
         else
           echo "Native test tasks not found"
         fi
-        matrixValue="{$(echo $nativeTestTasksEntry)\"java\":[\"${{ inputs.java }}\"]}"
+        matrixValue="{$(echo $nativeTestTasksEntry)}"
         echo "Created matrix: $matrixValue"
         echo "matrix=$matrixValue" >> $GITHUB_OUTPUT

--- a/graalvm/build-matrix/action.yml
+++ b/graalvm/build-matrix/action.yml
@@ -24,7 +24,6 @@ runs:
       with:
         distribution: ${{ inputs.distribution }}
         java-version: ${{ inputs.java }}
-        components: 'native-image'
 
     - name: "Setup Gradle"
       uses: gradle/gradle-build-action@v2
@@ -42,6 +41,6 @@ runs:
         else
           echo "Native test tasks not found"
         fi
-        matrixValue="{$(echo $nativeTestTasksEntry)\"distribution\":[\"${{ inputs.distribution }}\"],\"java\":[\"${{ inputs.java }}\"]}"
+        matrixValue="{$(echo $nativeTestTasksEntry)\"java\":[\"${{ inputs.java }}\"]}"
         echo "Created matrix: $matrixValue"
         echo "matrix=$matrixValue" >> $GITHUB_OUTPUT

--- a/graalvm/build-matrix/action.yml
+++ b/graalvm/build-matrix/action.yml
@@ -1,8 +1,8 @@
 name: Build matrix for graalvm workflow
 description: Creates matrix for graalvm workflow
 inputs:
-  graalvm:
-    description: 'GraalVM version'
+  distribution:
+    description: 'GraalVM distribution (graalvm, graalvm-community, or mandrel)'
     required: true
   java:
     description: 'Java version'
@@ -22,7 +22,7 @@ runs:
     - name: "Setup GraalVM CE"
       uses: graalvm/setup-graalvm@v1
       with:
-        version: ${{ inputs.graalvm }}
+        distribution: ${{ inputs.distribution }}
         java-version: ${{ inputs.java }}
         components: 'native-image'
 

--- a/graalvm/build-matrix/action.yml
+++ b/graalvm/build-matrix/action.yml
@@ -30,7 +30,7 @@ runs:
         if [[ "$gradleTasks" == *"nativeTest"* ]]; then
           echo "Found native test tasks"
           nativeTestTasks=$(echo "$gradleTasks" | grep -w "nativeTest" | sed 's/\(.*\) - Executes the test native binary/\"\1\"/' | tr '\n' ',' | sed 's/.$//')
-          nativeTestTasksEntry="\"native_test_task\":[$(echo $nativeTestTasks)],"
+          nativeTestTasksEntry="\"native_test_task\":[$(echo $nativeTestTasks)]"
         else
           echo "Native test tasks not found"
         fi

--- a/graalvm/build-matrix/action.yml
+++ b/graalvm/build-matrix/action.yml
@@ -33,6 +33,7 @@ runs:
           nativeTestTasksEntry="\"native_test_task\":[$(echo $nativeTestTasks)]"
         else
           echo "Native test tasks not found"
+          nativeTestTasksEntry="\"native_test_task\":[\"\"]"
         fi
         matrixValue="{$(echo $nativeTestTasksEntry)}"
         echo "Created matrix: $matrixValue"

--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -1,8 +1,8 @@
 name: Pre-build steps for graalvm workflow
 description: Runs pre-build steps for graalvm workflow
 inputs:
-  graalvm:
-    description: 'GraalVM version'
+  distribution:
+    description: 'GraalVM distribution (graalvm, graalvm-community, or mandrel)'
     required: true
   java:
     description: 'Java version'
@@ -27,7 +27,7 @@ runs:
     - name: "Setup GraalVM CE"
       uses: graalvm/setup-graalvm@v1
       with:
-        version: ${{ inputs.graalvm }}
+        distribution: ${{ inputs.distribution }}
         java-version: ${{ inputs.java }}
         components: 'native-image'
 

--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -27,7 +27,7 @@ runs:
     - name: "Setup GraalVM CE"
       uses: graalvm/setup-graalvm@v1
       with:
-        distribution: ${{ inputs.distribution }}
+
         java-version: ${{ inputs.java }}
         components: 'native-image'
 

--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -3,7 +3,7 @@ description: Runs pre-build steps for graalvm workflow
 inputs:
   distribution:
     description: 'GraalVM distribution (graalvm, graalvm-community, or mandrel)'
-    required: true
+    required: false
   java:
     description: 'Java version'
     required: true

--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -27,7 +27,7 @@ runs:
     - name: "Setup GraalVM CE"
       uses: graalvm/setup-graalvm@v1
       with:
-
+        distribution: ${{ inputs.distribution }}
         java-version: ${{ inputs.java }}
         components: 'native-image'
 

--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -25,7 +25,7 @@ runs:
         fetch-depth: 0
 
     - name: "Setup GraalVM CE"
-      uses: graalvm/setup-graalvm@v1.0.12
+      uses: graalvm/setup-graalvm@v1
       with:
         distribution: ${{ inputs.distribution }}
         java-version: ${{ inputs.java }}

--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -25,7 +25,7 @@ runs:
         fetch-depth: 0
 
     - name: "Setup GraalVM CE"
-      uses: graalvm/setup-graalvm@v1
+      uses: graalvm/setup-graalvm@v1.1.1
       with:
         distribution: ${{ inputs.distribution }}
         java-version: ${{ inputs.java }}


### PR DESCRIPTION
The changes from this PR are already used in the `micronaut-project-template` graalvm workflows (for example, [graalvm-dev.yml](https://github.com/micronaut-projects/micronaut-project-template/blob/master/.github/workflows/graalvm-dev.yml) is using `build-matrix@latest-graalvm-changes` task). Since all micronaut projects have been synced with `micronaut-project-template` workflows, we can push changes from this branch to the master branch and then modify workflows in the micronaut-project-template (replace `build-matrix@latest-graalvm-changes` with `build-matrix@master`, `pre-build@latest-graalvm-changes` with `pre-build@master`.

**Important**: Since we need to keep the `latest-graalvm-changes` branch until `micronaut-project-template` graalvm workflows start using github actions from the `master` branch, I created `latest-graalvm-changes-2` from `latest-graalvm-changes` so `latest-graalvm-changes` doesn't get deleted when pushing these changes to the `master` branch.

