### PR TITLE
Always run Gradle on JDK 17.

### DIFF
--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -24,14 +24,21 @@ runs:
       with:
         fetch-depth: 0
 
-    - name: "Setup GraalVM CE"
+    - name: "Set up $JAVA_HOME for Gradle"
+      uses: actions/setup-java@v3.12.0
+      with:
+        distribution: 'oracle'
+        java-version: '17'
+
+    - name: "Set up $GRAALVM_HOME for Native Build Tools"
       uses: graalvm/setup-graalvm@v1.1.1
       with:
         distribution: ${{ inputs.distribution }}
         java-version: ${{ inputs.java }}
         components: 'native-image'
+        set-java-home: 'false'
 
-    - name: "Setup Gradle"
+    - name: "Set up Gradle"
       uses: gradle/gradle-build-action@v2
 
     - name: "Optional setup step"


### PR DESCRIPTION
This PR makes sure that Gradle always runs on a JDK 17 by setting different `$JAVA_HOME` and `$GRAALVM_HOME` environment variables. This allows Micronaut to be built with GraalVM JDK 21+, even though Gradle itself does not support JDK21+ yet.

/cc @graemerocher