### PR TITLE
Force push the newly updated tag

### DIFF
--- a/pre-release/entrypoint.sh
+++ b/pre-release/entrypoint.sh
@@ -33,7 +33,9 @@ git add gradle.properties
 git commit -m "[skip ci] Release v${release_version}"
 git push origin $target_branch
 git tag -fa v${release_version} -m "Release v${release_version}"
-git push origin $target_branch --tags
+git push origin $target_branch
+# force push the updated tag
+git push origin v${release_version} --force
 
 echo "Closing again the release after updating the tag"
 release_url=`cat $GITHUB_EVENT_PATH | jq '.release.url' | sed -e 's/^"\(.*\)"$/\1/g'`


### PR DESCRIPTION
In https://github.com/micronaut-projects/github-actions/pull/33 we stopped deleting the updated tag prior to a push with `--tags`

This means the tag is not updated, as it already exists on the remote.

```
 ! [rejected]            v4.0.3 -> v4.0.3 (already exists)
error: failed to push some refs to 'https://github.com/micronaut-projects/micronaut-security'
hint: Updates were rejected because the tag already exists in the remote.
```

And we end up with the tag in the repo after release pointing to the prior commit.

This change stops using `--tags` (which attempts to push all tags), and instead force-pushes just the modified tag.

Hopefully this fixes https://github.com/micronaut-projects/micronaut-project-template/issues/389

However, I am not sure if it will break the problem we had with 80% of our releases that would stay "untagged" and back to draft after the release is complete.