### PR TITLE
Drop redundant `native-image` component.

### DIFF
--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -35,7 +35,6 @@ runs:
       with:
         distribution: ${{ inputs.distribution }}
         java-version: ${{ inputs.java }}
-        components: 'native-image'
         set-java-home: 'false'
 
     - name: "Set up Gradle"


### PR DESCRIPTION
Native Image is [included in the GraalVM JDK since the GraalVM for JDK 17 release](https://github.com/oracle/graal/pull/5995), so it's no longer necessary to specify it as a component. By removing this, setup-graalvm will not invoke the GraalVM updater (`gu install native-image` is essentially a nop, but it checks catalogs first), which in turn can fail sporadically when a new release is being rolled out. Fortunately, we have also retired [GraalVM updater in the GraalVM for JDK 21](https://github.com/oracle/graal/issues/6855), so this should no longer be an issue moving forward.