### PR TITLE
Use setup-graalvm v1.1.7

### DIFF
--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -31,7 +31,7 @@ runs:
         java-version: '17'
 
     - name: "Set up $GRAALVM_HOME for Native Build Tools"
-      uses: graalvm/setup-graalvm@v1.1.4.2
+      uses: graalvm/setup-graalvm@v1.1.7
       with:
         distribution: ${{ inputs.distribution }}
         java-version: ${{ inputs.java }}


### PR DESCRIPTION
This is needed to make Oracle GraalVM EA builds available via `22-ea`.