### PR TITLE
Upgrade to `setup-java@v4.2.0`.

### DIFF
--- a/graalvm/build-matrix/action.yml
+++ b/graalvm/build-matrix/action.yml
@@ -13,7 +13,7 @@ runs:
         fetch-depth: 0
 
     - name: "Set up $JAVA_HOME for Gradle"
-      uses: actions/setup-java@v4.0.0
+      uses: actions/setup-java@v4.2.0
       with:
         distribution: 'oracle'
         java-version: '17'

--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -25,7 +25,7 @@ runs:
         fetch-depth: 0
 
     - name: "Set up $JAVA_HOME for Gradle"
-      uses: actions/setup-java@v4.0.0
+      uses: actions/setup-java@v4.2.0
       with:
         distribution: 'oracle'
         java-version: '17'


### PR DESCRIPTION
[`v4.2.0`](https://github.com/actions/setup-java/releases/tag/v4.2.0) has [upgraded the http-client](https://github.com/actions/setup-java/pull/607), which in turn fixes https://github.com/actions/setup-java/issues/596 and thus speeds up builds.