### PR TITLE
ISSUE-46 - GitHub Action Job can fail because of SUDO commands, in case Runners don't have SUDOER privilege

### DIFF
--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -14,9 +14,9 @@ runs:
     - name: "Free disk space"
       shell: bash
       run: |
-        sudo rm -rf "/usr/local/share/boost"
-        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-        sudo apt-get clean
+        sudo -n rm -rf "/usr/local/share/boost" || true
+        sudo -n rm -rf "$AGENT_TOOLSDIRECTORY" || true
+        sudo -n apt-get clean || true
         df -h
 
     - name: "Checkout repository"


### PR DESCRIPTION
Hi,
this PR should address the [Issue 46](https://github.com/micronaut-projects/github-actions/issues/46).

Thanks