### PR TITLE
Add `gradle-java` input

### DIFF
--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -7,6 +7,10 @@ inputs:
   java:
     description: 'Java version'
     required: true
+  gradle-java:
+    description: 'Java version for running Gradle'
+    required: false
+    default: '17'
 runs:
   using: "composite"
   steps:
@@ -28,7 +32,7 @@ runs:
       uses: actions/setup-java@v4.2.0
       with:
         distribution: 'oracle'
-        java-version: '17'
+        java-version: ${{ inputs.gradle-java }}
 
     - name: "Set up $GRAALVM_HOME for Native Build Tools"
       uses: graalvm/setup-graalvm@v1.2.4


### PR DESCRIPTION
This parameter determines the Java version for the Gradle build itself, which may differ from the GraalVM version.