### PR TITLE
graalvm/setup-graalvm upgrade

### DIFF
--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -39,7 +39,7 @@ runs:
         java-version: ${{ inputs.gradle-java }}
 
     - name: "Set up $GRAALVM_HOME for Native Build Tools"
-      uses: graalvm/setup-graalvm@v1.2.4
+      uses: graalvm/setup-graalvm@v1.4.5
       with:
         distribution: ${{ inputs.distribution }}
         java-version: ${{ inputs.java }}

--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -10,7 +10,7 @@ inputs:
   gradle-java:
     description: 'Java version for running Gradle'
     required: false
-    default: '17'
+    default: '21'
   nativeTestTask:
     description: 'Native test task that will be executed'
     required: false


### PR DESCRIPTION
Mapping of setup-graalvm input variables to resulting graalvm versions that will be used in our builds after the PR is merged:
- distribution: graalvm-community, java-version: dev => graalvm-community-25.1.0-dev+8.1
- distribution: graalvm, java-version: latest-ea => graalvm-jdk-25+37.1
- distribution: graalvm, java-version: 25 => graalvm-jdk-25.0.2+10.1