### PR TITLE
Enable GraalVM native-image job reports in pre-build action

### DIFF
--- a/graalvm/pre-build/action.yml
+++ b/graalvm/pre-build/action.yml
@@ -44,6 +44,7 @@ runs:
         distribution: ${{ inputs.distribution }}
         java-version: ${{ inputs.java }}
         set-java-home: 'false'
+        native-image-job-reports: true
 
     - name: "Set up Gradle"
       uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
## Summary
- enable GraalVM native-image job reports in the shared `graalvm/pre-build` composite action
- keep the existing action inputs, action versions, Java setup, Gradle setup, and optional setup behavior unchanged

## Review Notes
- Target branch: `master`.
- Release target: default-branch shared CI action maintenance; workflow/action diagnostics only, non-breaking.
- Companion PR: micronaut-projects/micronaut-project-template#723.
- Micronaut organization projects selected during QA: `5.0.0-M3` and `5.0.0 Release`.
- Project-selection ambiguity carried from QA: `micronaut-project-template` and this shared action repository do not map cleanly to a module artifact release consumed directly by the Micronaut Platform BOM, so the selected projects follow the current default-branch Micronaut Platform line.

## Verification
- `ruby` YAML assertion confirmed the existing `graalvm/setup-graalvm@v1.4.5` step now has boolean `native-image-job-reports: true`, while existing inputs remain `distribution`, `java`, `gradle-java`, and `nativeTestTask`.
- Repository-wide YAML walk parsed all 12 YAML files, found exactly one direct `graalvm/setup-graalvm` step, and found exactly one `native-image-job-reports` key with value `true`.
- `git diff --check origin/master...HEAD` passed.

## PR Assets
- None required; this is a composite GitHub Action metadata change with no rendered or generated artifacts.

Fixes micronaut-projects/micronaut-project-template#722

---
###### ✨ This message was AI-generated using gpt-5