### PR TITLE
oci cli did a breaking change the TERMINATED doesn't exists anymore

### DIFF
--- a/stop-oracle-cloud-runners/action.yml
+++ b/stop-oracle-cloud-runners/action.yml
@@ -19,7 +19,7 @@ runs:
         for ID in $(oci compute instance list --compartment-id ${{ inputs.oci-compartment-ocid }} | \
          jq -r ".data[] | select( .\"freeform-tags\".repository == \"$GITHUB_REPOSITORY\" and .\"freeform-tags\".label == \"$RUNNER_LABEL\" ) | .id")
         do
-          oci compute instance terminate --instance-id "$ID"  --wait-for-state TERMINATED --force
+          oci compute instance terminate --instance-id "$ID"  --wait-for-state SUCCEEDED --force
         done
         RUNNERS_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runners"
         for RUNNER_ID in $(curl -X GET -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ inputs.github-token }}" ${RUNNERS_URL}  | \


### PR DESCRIPTION
The TERMINATED status doesn't exists anymore.


```Warning: To increase security of your API key located at /home/runner/.oci/key.pem, append an extra line with 'OCI_API_KEY' at the end. For more information, refer to https://docs.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm. To suppress the warning, set the env variable SUPPRESS_LABEL_WARNING=True
Warning: To increase security of your API key located at /home/runner/.oci/key.pem, append an extra line with 'OCI_API_KEY' at the end. For more information, refer to https://docs.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm. To suppress the warning, set the env variable SUPPRESS_LABEL_WARNING=True
Usage: oci compute instance terminate [OPTIONS]

Error: Invalid value for '--wait-for-state': invalid choice: TERMINATED. (choose from ACCEPTED, IN_PROGRESS, FAILED, SUCCEEDED)

For OCI CLI commands and parameters suggestion, auto completion and other useful features, try the Interactive mode by typing `oci -i`.```