### PR TITLE
Fix graalvm native tests execution after update to 1.1.2 native build plugin

### DIFF
--- a/graalvm/build-matrix/action.yml
+++ b/graalvm/build-matrix/action.yml
@@ -34,7 +34,7 @@ runs:
         gradleTasks=$(./gradlew tasks --no-daemon --all)
         if [[ "$gradleTasks" == *"nativeTest"* ]]; then
           echo "Found native test tasks"
-          nativeTestTasks=$(echo "$gradleTasks" | grep -w "nativeTest" | sed 's/\(.*\) - Executes the test native binary/\"\1\"/' | tr '\n' ',' | sed 's/.$//')
+          nativeTestTasks=$(echo "$gradleTasks" | sed -n 's/^\([^ ]*:nativeTest\) - .*/"\1"/p' | tr '\n' ',' | sed 's/.$//')
           nativeTestTasksEntry="\"native_test_task\":[$(echo $nativeTestTasks)]"
         else
           echo "Native test tasks not found"


### PR DESCRIPTION
Native build plugin 1.1.2 changes description from `Executes the test native binary` to `Runs the test native binary.`  so now tasks are not recognized. This change is to have more generic recognition of `nativeTest` and not looking for exact description. Should support old and new plugin